### PR TITLE
Removed 'last' wrong parameters

### DIFF
--- a/motd.sh
+++ b/motd.sh
@@ -97,7 +97,7 @@ greetings="$borderBar$(color $greetingsColor "$(center "Welcome back, $me!")")$b
 greetings="$greetings$borderBar$(color $greetingsColor "$(center "$(date +"%A, %d %B %Y, %T")")")$borderBar"
 
 # System information
-read loginFrom loginIP loginDate <<< $(last $me --time-format iso -2 | awk 'NR==2 { print $2,$3,$4 }')
+read loginFrom loginIP loginDate <<< $(last $me | awk 'NR==2 { print $2,$3,$4 }')
 
 # TTY login
 if [[ $loginDate == - ]]; then


### PR DESCRIPTION
That parameter throws up an error (at least in Raspbian), so I removed it and everything works fine, even the hour.
