### PR TITLE
/opt/vc/bin/vcgencmd to /usr/bin/vcgencmd

### DIFF
--- a/motd.sh
+++ b/motd.sh
@@ -127,7 +127,7 @@ label3="$borderBar  $(color $statsLabelColor "Memory........:") $label3$borderBa
 label4="$(extend "$(df -h ~ | awk 'NR==2 { printf "Total: %sB, Used: %sB, Free: %sB",$2,$3,$4; }')")"
 label4="$borderBar  $(color $statsLabelColor "Home space....:") $label4$borderBar"
 
-label5="$(extend "$(/opt/vc/bin/vcgencmd measure_temp | cut -c "6-9")ºC")"
+label5="$(extend "$(/usr/bin/vcgencmd measure_temp | cut -c "6-9")ºC")"
 label5="$borderBar  $(color $statsLabelColor "Temperature...:") $label5$borderBar"
 
 stats="$label1\n$label2\n$label3\n$label4\n$label5"


### PR DESCRIPTION
Raspberry Pi OS moved vcgencmd, thus requiring the change from `/opt/vc/bin/vcgencmd` to `/usr/bin/vcgencmd` for the temperature reading to function.